### PR TITLE
Fix missing model argument

### DIFF
--- a/textToKnowledgeGraph/main.py
+++ b/textToKnowledgeGraph/main.py
@@ -123,7 +123,8 @@ def process_file_document(file_path, api_key, pmid_or_pmcid=None, custom_name=No
                           ndex_password=None, 
                           prompt_file="prompt_file_v7.txt",
                           prompt_identifier="general prompt",
-                          style_path=None, upload_to_ndex=False):
+                          style_path=None, upload_to_ndex=False,
+                          model="gpt-4o-mini"):
     """
     Process a document given a file path (PDF or TXT).
     Steps:
@@ -151,7 +152,8 @@ def process_file_document(file_path, api_key, pmid_or_pmcid=None, custom_name=No
 
         logging.info("Processing annotated paragraphs with the LLM-BEL model")
         llm_results = llm_bel_processing(annotated_paragraphs, api_key, 
-                                         prompt_file=prompt_file, prompt_identifier=prompt_identifier)
+                                         prompt_file=prompt_file, prompt_identifier=prompt_identifier,
+                                         model=model)
         llm_filename = 'llm_results.json'
         save_to_json(llm_results, llm_filename, output_dir)
 


### PR DESCRIPTION
This PR fixes a small issue in how the optional `model` argument is used in certain functions. It adds the `model` argument to `process_file_document` (previously this being missing caused an unrecognized argument error when called from `main`) and then makes sure that the argument is passed on to `llm_bel_processing`.