### PR TITLE
fix: update matplotlib and libdeeplake for Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ gilda==1.4.0
 langchain==0.3.25
 langchain_core==0.3.60
 langchain_openai==0.3.17
-libdeeplake==0.0.96
+libdeeplake==0.0.164
 lxml==5.2.1
 markitdown==0.1.1
-matplotlib==3.8.4
+matplotlib==3.10.3
 ndex2>=3.8.0,<4.0.0
 openai==1.79.0
 pydantic==2.11.4


### PR DESCRIPTION
## Summary

`matplotlib==3.8.4` has no pre-built wheel for Python 3.13 on macOS arm64 and fails to compile from source due to FreeType/zlib type errors with newer Clang toolchains. This PR updates the pinned versions in `requirements.txt`:

- **matplotlib**: 3.8.4 → 3.10.3 (ships cp313 wheels)
- **libdeeplake**: 0.0.96 → 0.0.164 (aligns with already-installed version)

## Verification

- All packages install successfully with `pip install -r requirements.txt` on Python 3.13
- All core application modules import without errors (`main`, `convert_to_cx2`, `grounding_genes`, `sentence_level_extraction`, `transform_bel_statements`)

## Pre-existing test failures (not introduced by this PR)

Two test issues exist on `main` prior to this change:

1. **`tests/test_main.py::test_process_paper`** — `TypeError: process_paper() takes from 0 to 2 positional arguments but 3 were given`. The test imports `process_paper` from `textToKnowledgeGraph.main`, but the function signature was refactored (`process_pmc_document` / `process_file_document`) and the test was not updated to match.

2. **`tests/test_hgnc_grounding.py`** — `ModuleNotFoundError: No module named 'hgnc_grounding'`. The test references a module that does not exist in the repository.

Additionally, `pytest-asyncio` (installed as a transitive dependency) is incompatible with the pinned `pytest==7.4.4` — it requires `pytest>=8.4` and attempts to import `FixtureDef` which was added in pytest 8. Tests can be run with `-p no:asyncio` to work around this.

---

Co-Authored-By: Oz <oz-agent@warp.dev>
[Warp conversation](https://app.warp.dev/conversation/fb2816ce-3033-424b-9b9b-e43641e7900e)